### PR TITLE
Split by `=`, not by `:`

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,10 @@ repos:
             "--skip=another_project",
             # You can specify that a given hook id (like "pyright-python")
             # should be mapped to a given PyPI package name (like "pyright")
-            "--map=pyright-python:pyright",
-            "--map=ruff-pre-commit:ruff",
+            "--map",
+            "pyright-python=pyright",
+            "--map",
+            "ruff-pre-commit=ruff",
           ]
 
       # Use this hook to sync a specific hook with a Poetry group, adding all
@@ -45,7 +47,7 @@ repos:
         # "mypy" is the id of a pre-commit hook
         # "types" is the name of your poetry group containing typing dependencies
         # "main" is the automated name associated with the "default" poetry dependencies
-        args: ["--bind", "mypy:types,main"]
+        args: ["--bind", "mypy=types,main"]
 ```
 
 ## How it works
@@ -67,7 +69,7 @@ leading `v`).
 
 ### `sync-hooks-additional-dependencies_cli`
 
-This hook will iterate over all the `--bind {pre-commit-hook}:{poetry_groups}`
+This hook will iterate over all the `--bind {pre-commit-hook}={poetry_groups}`
 arguments you provided, and for each of them, it will look for the
 corresponding groups in your `pyproject.toml`. If it finds it, then it will
 look for the version of all the dependencies of these groups in your

--- a/poetry_to_pre_commit/sync_hooks_additional_dependencies.py
+++ b/poetry_to_pre_commit/sync_hooks_additional_dependencies.py
@@ -15,10 +15,10 @@ PRE_COMMIT_CONFIG_FILE = pathlib.Path(".pre-commit-config.yaml")
 
 def format_bind(value: str) -> tuple[str, set[str]]:
     try:
-        key, value = value.split(":", 1)
+        key, value = value.split("=", 1)
     except ValueError:
         raise ValueError(
-            f"Invalid bind value: {value}. Expected format: pre_commit_hook_id:poetry_group[,poetry_group,...]."
+            f"Invalid bind value: {value}. Expected format: pre_commit_hook_id=poetry_group[,poetry_group,...]."
         )
     return key, set(value.split(","))
 
@@ -38,13 +38,13 @@ def get_sync_hooks_additional_dependencies_parser() -> argparse.ArgumentParser:
         type=format_bind,
         action="append",
         default=[],
-        help="Bind pre-commit hook ids to poetry group names (e.g. mypy:types). "
+        help="Bind pre-commit hook ids to poetry group names (e.g. mypy=types). "
         "To add the main package dependencies, use the poetry group name "
         f"`{MAIN_GROUP}`. You can bind multiple poetry groups to a single hook "
         "id by either using multiple flags, or by providing a comma-separated "
         "list of poetry group names (e.g. "
-        f"`--bind mypy:{MAIN_GROUP} --bind mypy:types` or "
-        f"`--bind mypy:{MAIN_GROUP},types`).",
+        f"`--bind mypy={MAIN_GROUP} --bind mypy:types` or "
+        f"`--bind mypy={MAIN_GROUP},types`).",
     )
     return parser
 

--- a/poetry_to_pre_commit/sync_repos.py
+++ b/poetry_to_pre_commit/sync_repos.py
@@ -30,9 +30,9 @@ def get_sync_repos_parser() -> argparse.ArgumentParser:
         "--map",
         action="append",
         default=[],
-        type=lambda x: tuple(x.split(":")),
+        type=lambda x: tuple(x.split("=")),
         help="Map repo name to PyPI name in case of mismatch "
-        "(e.g. 'pyright-python:pyright'). Note: if the repo name "
+        "(e.g. 'pyright-python=pyright'). Note: if the repo name "
         "is a mirror, the prefix 'mirrors-' is assumed, you don't need to explicit it. "
         "Flag can be repeated multiple times.",
     )

--- a/tests/test_sync_hooks_additional_dependencies.py
+++ b/tests/test_sync_hooks_additional_dependencies.py
@@ -9,8 +9,8 @@ from poetry_to_pre_commit import sync_hooks_additional_dependencies
 @pytest.mark.parametrize(
     "value,expected",
     [
-        ("foo:bar", ("foo", {"bar"})),
-        ("foo:bar,baz", ("foo", {"bar", "baz"})),
+        ("foo=bar", ("foo", {"bar"})),
+        ("foo=bar,baz", ("foo", {"bar", "baz"})),
     ],
 )
 def test_format_bind(value, expected):
@@ -32,7 +32,7 @@ def test_combine_bind_values():
 
 def test_get_sync_hooks_additional_dependencies_parser():
     parser = sync_hooks_additional_dependencies.get_sync_hooks_additional_dependencies_parser()
-    assert parser.parse_args(["--bind", "foo:bar,baz", "--bind", "foo:qux"]).bind == [
+    assert parser.parse_args(["--bind", "foo=bar,baz", "--bind", "foo=qux"]).bind == [
         ("foo", {"bar", "baz"}),
         ("foo", {"qux"}),
     ]
@@ -110,7 +110,7 @@ def test_sync_hooks_additional_dependencies(tmp_path, poetry_cwd):
     )
 
     sync_hooks_additional_dependencies.sync_hooks_additional_dependencies(
-        argv=["foo", "--bind", "pyright:types,main"],
+        argv=["foo", "--bind", "pyright=types,main"],
         pre_commit_path=pre_commit_path,
         poetry_cwd=poetry_cwd,
     )

--- a/tests/test_sync_repos.py
+++ b/tests/test_sync_repos.py
@@ -32,7 +32,7 @@ def test_repo_url_to_pypi_name(input, expected):
             {"filenames": [], "map": [], "skip": ["foo", "bar"]},
         ),
         (
-            ["--map", "foo:bar", "--map", "baz:qux"],
+            ["--map", "foo=bar", "--map", "baz=qux"],
             {"filenames": [], "map": [("foo", "bar"), ("baz", "qux")], "skip": []},
         ),
     ],
@@ -127,7 +127,7 @@ def test_sync_repos(tmp_path, poetry_cwd):
     )
 
     sync_repos.sync_repos(
-        argv=["foo", "--map", "pyright-python:pyright"],
+        argv=["foo", "--map", "pyright-python=pyright"],
         pre_commit_path=pre_commit_path,
         poetry_cwd=poetry_cwd,
     )


### PR DESCRIPTION
Yaml interprets `:` specifically, so it's easier if we use a different symbol 

### Successful PR Checklist:

- [x] Tests
  - [ ] (not applicable?)
- [ ] Documentation
  - [x] (not applicable?)

#### PR label(s): <!-- It's easier to fill those after submitting your PR -->

- [x] <!-- Breaking -->https://github.com/ewjoachim/poetry_to_pre_commit/labels/PR%20type%3A%20breaking%20%F0%9F%92%A5
- [ ] <!-- Feature -->https://github.com/ewjoachim/poetry_to_pre_commit/labels/PR%20type%3A%20feature%20%E2%AD%90%EF%B8%8F
- [ ] <!-- Bugfix -->https://github.com/ewjoachim/poetry_to_pre_commit/labels/PR%20type%3A%20bugfix%20%F0%9F%95%B5%EF%B8%8F
- [ ] <!-- Misc. -->https://github.com/ewjoachim/poetry_to_pre_commit/labels/PR%20type%3A%20miscellaneous%20%F0%9F%91%BE
- [ ] <!-- Deps -->https://github.com/ewjoachim/poetry_to_pre_commit/labels/PR%20type%3A%20dependencies%20%F0%9F%A4%96
- [ ] <!-- Docs -->https://github.com/ewjoachim/poetry_to_pre_commit/labels/PR%20type%3A%20documentation%20%F0%9F%93%9A
