### PR TITLE
poetry-dynamic-versionning: Specify vcs is git to avoid having to autodetect

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ pytest-mock = "*"
 [tool.poetry-dynamic-versioning]
 enable = true
 pattern = '(?P<base>\d+(\.\d+)*)([-._]?((?P<stage>[a-zA-Z]+)[-._]?(?P<revision>\d+)?))?$'
+vcs = 'git'
 
 [tool.pytest.ini_options]
 addopts = [


### PR DESCRIPTION
Relates to #7 

### Successful PR Checklist:

- [ ] Tests
  - [x] (not applicable?)
- [ ] Documentation
  - [x] (not applicable?)

#### PR label(s): <!-- It's easier to fill those after submitting your PR -->

- [ ] <!-- Breaking -->https://github.com/ewjoachim/poetry_to_pre_commit/labels/PR%20type%3A%20breaking%20%F0%9F%92%A5
- [ ] <!-- Feature -->https://github.com/ewjoachim/poetry_to_pre_commit/labels/PR%20type%3A%20feature%20%E2%AD%90%EF%B8%8F
- [x] <!-- Bugfix -->https://github.com/ewjoachim/poetry_to_pre_commit/labels/PR%20type%3A%20bugfix%20%F0%9F%95%B5%EF%B8%8F
- [ ] <!-- Misc. -->https://github.com/ewjoachim/poetry_to_pre_commit/labels/PR%20type%3A%20miscellaneous%20%F0%9F%91%BE
- [ ] <!-- Deps -->https://github.com/ewjoachim/poetry_to_pre_commit/labels/PR%20type%3A%20dependencies%20%F0%9F%A4%96
- [ ] <!-- Docs -->https://github.com/ewjoachim/poetry_to_pre_commit/labels/PR%20type%3A%20documentation%20%F0%9F%93%9A
