### PR TITLE
refactor: `get_poetry_deps` leverages `common.PoetryPackage`

### DIFF
--- a/poetry_to_pre_commit/common.py
+++ b/poetry_to_pre_commit/common.py
@@ -23,10 +23,18 @@ def pre_commit_config_roundtrip(
         yaml.dump(config, path)
 
 
-@dataclasses.dataclass
+@dataclasses.dataclass(frozen=True, order=True)
 class PoetryPackage:
     name: str
-    version: str
+    version: str = "*"
+    extras: frozenset[str] = dataclasses.field(default_factory=frozenset)
+
+    def __str__(self) -> str:
+        if self.extras:
+            extras = ",".join(sorted(self.extras))
+            return f"{self.name}[{extras}]=={self.version}"
+        else:
+            return f"{self.name}=={self.version}"
 
 
 def get_poetry_packages(cwd: pathlib.Path | None = None) -> Iterable[PoetryPackage]:
@@ -35,6 +43,5 @@ def get_poetry_packages(cwd: pathlib.Path | None = None) -> Iterable[PoetryPacka
 
     for package in repository.packages:
         yield PoetryPackage(
-            name=package.name,
-            version=package.version.text,
+            name=package.name, version=package.version.text, extras=package.features
         )


### PR DESCRIPTION
Also add `extras` field to `common.PoetryPackage`. This allows to clean `update_or_remove_additional_deps` in `sync_hooks_additional_dependencies.py`

### Successful PR Checklist:

- [ ] Tests
  - [ ] (not applicable?)
- [ ] Documentation
  - [ ] (not applicable?)

#### PR label(s): <!-- It's easier to fill those after submitting your PR -->

- [ ] <!-- Breaking -->https://github.com/ewjoachim/poetry-to-pre-commit/labels/breaking
- [ ] <!-- Feature -->https://github.com/ewjoachim/poetry-to-pre-commit/labels/feature
- [ ] <!-- Bugfix -->https://github.com/ewjoachim/poetry-to-pre-commit/labels/bugfix
- [x] <!-- Misc. -->https://github.com/ewjoachim/poetry-to-pre-commit/labels/miscellaneous
- [ ] <!-- Deps -->https://github.com/ewjoachim/poetry-to-pre-commit/labels/dependencies
- [ ] <!-- Docs -->https://github.com/ewjoachim/poetry-to-pre-commit/labels/documentation
