### PR TITLE
Don't use poetry-dynamic-versioning: it's incompatible with pre-commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,43 @@
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to release"
+        required: true
+        type: string
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install poetry
+        run: pipx install poetry
+
+      - uses: actions/setup-python@v5
+        with:
+          cache: "poetry"
+
+      - run: poetry install
+
+      - run: poetry version "${{ github.event.inputs.tag }}"
+
+      - run: git commit -am "Release ${{ github.event.inputs.tag }}"
+        env:
+          GIT_AUTHOR_NAME: "GitHub Actions"
+          GIT_AUTHOR_EMAIL: "41898282+github-actions[bot]@users.noreply.github.com"
+          GIT_COMMITTER_NAME: "GitHub Actions"
+          GIT_COMMITTER_EMAIL: "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - run: git push origin
+
+      - run: >
+          gh release create "${{ github.event.inputs.tag }}"
+          --title "${{ github.event.inputs.tag }}"
+          --generate-notes
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,28 @@
+# Contributing
+
+Contributions are welcome! The project is quite small so feel free to
+familiarize yourself with the codebase and open an issue or a pull request.
+Before doing anything important, feel free to open an issue to discuss it.
+
+All interactions are required to follow the
+[Code of Conduct](CODE_OF_CONDUCT.md) which sets rules for the community.
+
+## Development
+
+The project uses [Poetry](https://python-poetry.org/),
+[pre-commit](https://pre-commit.com/), and
+[pytest](https://docs.pytest.org/en/stable/).
+
+```console
+$ poetry install
+$ pre-commit install
+$ poetry run pytest
+```
+
+If you have any questions, feel free to ask them in the issues.
+
+# Internal documentation
+
+## Releasing
+
+Launch the `Release`worfklow with the desired tag.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,10 +1,10 @@
 [build-system]
-requires = ["poetry-core", "poetry-dynamic-versioning"]
-build-backend = "poetry_dynamic_versioning.backend"
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"
 
 [tool.poetry]
 name = "poetry_to_pre_commit"
-version = "0.0.0"
+version = "2.1.0"
 description = "Sync versions in .pre-commit-config.yaml from poetry.lock"
 authors = ["Joachim Jablon"]
 license = "MIT License"
@@ -40,11 +40,6 @@ ruff = "*"
 pytest = "*"
 pytest-cov = "*"
 pytest-mock = "*"
-
-[tool.poetry-dynamic-versioning]
-enable = true
-pattern = '(?P<base>\d+(\.\d+)*)([-._]?((?P<stage>[a-zA-Z]+)[-._]?(?P<revision>\d+)?))?$'
-vcs = 'git'
 
 [tool.pytest.ini_options]
 addopts = [


### PR DESCRIPTION
Closes #7

Don't use poetry-dynamic-versioning. Instead, version number is set when releasing through a GHA workflow.

### Successful PR Checklist:

- [ ] Tests
  - [x] (not applicable?)
- [x] Documentation
  - [ ] (not applicable?)

#### PR label(s): <!-- It's easier to fill those after submitting your PR -->

- [ ] <!-- Breaking -->https://github.com/ewjoachim/poetry-to-pre-commit/labels/breaking
- [ ] <!-- Feature -->https://github.com/ewjoachim/poetry-to-pre-commit/labels/feature
- [ ] <!-- Bugfix -->https://github.com/ewjoachim/poetry-to-pre-commit/labels/bugfix
- [x] <!-- Misc. -->https://github.com/ewjoachim/poetry-to-pre-commit/labels/miscellaneous
- [ ] <!-- Deps -->https://github.com/ewjoachim/poetry-to-pre-commit/labels/dependencies
- [ ] <!-- Docs -->https://github.com/ewjoachim/poetry-to-pre-commit/labels/documentation
